### PR TITLE
feat: add apply_random_scroll effect. 

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/EcoScrollsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/EcoScrollsPlugin.kt
@@ -14,6 +14,7 @@ import com.willfp.ecoscrolls.config.TypesYml
 import com.willfp.ecoscrolls.display.ScrollDisplay
 import com.willfp.ecoscrolls.gui.updateInscribeMenu
 import com.willfp.ecoscrolls.libreforge.ConditionHasScroll
+import com.willfp.ecoscrolls.libreforge.EffectApplyRandomScroll
 import com.willfp.ecoscrolls.libreforge.EffectInscribeItem
 import com.willfp.ecoscrolls.libreforge.EffectUninscribeItem
 import com.willfp.ecoscrolls.libreforge.FilterScroll
@@ -58,6 +59,7 @@ class EcoScrollsPlugin : LibreforgePlugin() {
         Conditions.register(ConditionHasScroll)
         Effects.register(EffectInscribeItem)
         Effects.register(EffectUninscribeItem)
+        Effects.register(EffectApplyRandomScroll)
         Filters.register(FilterScroll)
         Triggers.register(TriggerInscribe)
         Triggers.register(TriggerTryInscribe)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/libreforge/EffectApplyRandomScroll.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/libreforge/EffectApplyRandomScroll.kt
@@ -1,0 +1,42 @@
+package com.willfp.ecoscrolls.libreforge
+
+import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.ecoscrolls.scrolls.Scroll
+import com.willfp.ecoscrolls.scrolls.ScrollTypes
+import com.willfp.ecoscrolls.scrolls.Scrolls
+import com.willfp.libreforge.NoCompileData
+import com.willfp.libreforge.effects.Effect
+import com.willfp.libreforge.triggers.TriggerData
+
+object EffectApplyRandomScroll : Effect<NoCompileData>("apply_random_scroll") {
+    override val isPermanent = false
+
+    override fun onTrigger(config: Config, data: TriggerData, compileData: NoCompileData): Boolean {
+        val item = data.foundItem ?: return false
+
+        val allowUnsafe = config.getBool("allow_unsafe")
+
+        val scrollList = config.getStrings("scrolls")
+        var candidates: Collection<Scroll> = if (scrollList.isNotEmpty()) {
+            scrollList.mapNotNull { Scrolls[it] }
+        } else {
+            Scrolls.values()
+        }
+
+        val typeId = config.getStringOrNull("type")
+        if (typeId != null) {
+            val type = ScrollTypes[typeId] ?: return false
+            candidates = candidates.filter { it.type == type }
+        }
+
+        val applicable = candidates.filter {
+            if (allowUnsafe) it.matchesTarget(item) else it.canInscribe(item)
+        }
+
+        val scroll = applicable.randomOrNull() ?: return false
+
+        scroll.inscribe(item)
+
+        return true
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/scrolls/Scroll.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecoscrolls/scrolls/Scroll.kt
@@ -222,6 +222,8 @@ class Scroll(
 
     fun canInscribe(itemStack: ItemStack): Boolean = getDenialReason(itemStack) == null
 
+    fun matchesTarget(itemStack: ItemStack): Boolean = targets.any { it.matches(itemStack) }
+
     fun getDenialReason(itemStack: ItemStack): InscriptionDenialReason? {
         if (targets.none { it.matches(itemStack) }) {
             return InscriptionDenialReason.OTHER


### PR DESCRIPTION
Applies a random scroll to the trigger item - adhering to targets, limits, types, conflicts, and requirements. 
Optional args: 
type: only scrolls matching type 
scroll: only scrolls in list 
allow_unsafe: bypass limits, conflicts and requirements - only adhering to target (and other args above)
